### PR TITLE
CI: Force colored output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron:  '0 3 * * *' # daily, at 3am
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   lint:
     name: Linting


### PR DESCRIPTION
Looks like Jest does not detect GitHub Actions automatically... 😢 