### PR TITLE
no-perform-without-catch: Adjust report node

### DIFF
--- a/rules/no-perform-without-catch.js
+++ b/rules/no-perform-without-catch.js
@@ -15,7 +15,7 @@ module.exports = {
         if (effectiveParent.type !== 'ExpressionStatement') return;
 
         context.report({
-          node: node,
+          node: property,
           message: 'Unhandled promise error from `perform()` call',
         });
       },

--- a/rules/no-perform-without-catch.test.js
+++ b/rules/no-perform-without-catch.test.js
@@ -29,13 +29,13 @@ ruleTester.run('no-perform-without-catch', rule, {
     {
       code: `function foo() { this.submitTask.perform(); }`,
       errors: [
-        { message: 'Unhandled promise error from `perform()` call', column: 18, endColumn: 43 },
+        { message: 'Unhandled promise error from `perform()` call', column: 34, endColumn: 41 },
       ],
     },
     {
       code: `function foo() { this.submitTask.perform().then().then(); }`,
       errors: [
-        { message: 'Unhandled promise error from `perform()` call', column: 18, endColumn: 43 },
+        { message: 'Unhandled promise error from `perform()` call', column: 34, endColumn: 41 },
       ],
     },
   ],


### PR DESCRIPTION
... to make IntellliJ highlight the right node 😅 

<img width="506" alt="Bildschirmfoto 2020-10-29 um 23 00 05" src="https://user-images.githubusercontent.com/141300/97637210-82cf9680-1a3a-11eb-8fa5-1efc88209567.png">
